### PR TITLE
feat: guard against filename too long not saving markdown

### DIFF
--- a/maestro.py
+++ b/maestro.py
@@ -2,6 +2,7 @@ from anthropic import Anthropic
 import re
 from rich.console import Console
 from rich.panel import Panel
+import hashlib
 
 # Set up the Anthropic API client
 client = Anthropic(api_key="")
@@ -114,7 +115,13 @@ exchange_log += refined_output
 console.print(f"\n[bold]Refined Final output:[/bold]\n{refined_output}")
 
 # Save the full exchange log to a file
-filename = re.sub(r'\W+', '_', objective) + ".md"
+# Ensure the objective doesn't contain any special characters
+sanitized_objective = re.sub(r'\W+', '_', objective)
+# Create a unique identifier of objective
+filename_hash_prefix = hashlib.md5(sanitized_objective.encode('utf-8')).hexdigest()
+
+filename = f"{filename_hash_prefix}_{sanitized_objective[:50]}.md" if len(sanitized_objective) > 50 else f"{filename_hash_prefix}_{sanitized_objective}.md"
+
 with open(filename, 'w') as file:
     file.write(exchange_log)
 print(f"\nFull exchange log saved to {filename}")

--- a/maestro.py
+++ b/maestro.py
@@ -2,10 +2,10 @@ from anthropic import Anthropic
 import re
 from rich.console import Console
 from rich.panel import Panel
-import hashlib
+from datetime import datetime
 
 # Set up the Anthropic API client
-client = Anthropic(api_key="")
+client = Anthropic()
 
 # Initialize the Rich Console
 console = Console()
@@ -114,13 +114,11 @@ exchange_log += refined_output
 
 console.print(f"\n[bold]Refined Final output:[/bold]\n{refined_output}")
 
-# Save the full exchange log to a file
-# Ensure the objective doesn't contain any special characters
 sanitized_objective = re.sub(r'\W+', '_', objective)
 # Create a unique identifier of objective
-filename_hash_prefix = hashlib.md5(sanitized_objective.encode('utf-8')).hexdigest()
-
-filename = f"{filename_hash_prefix}_{sanitized_objective[:50]}.md" if len(sanitized_objective) > 50 else f"{filename_hash_prefix}_{sanitized_objective}.md"
+timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+# Guard against filename too long OS errors by conditionally combining unique hash as prefix
+filename = f"{timestamp}_{sanitized_objective[:50]}.md" if len(sanitized_objective) > 50 else f"{timestamp}_{sanitized_objective}.md"
 
 with open(filename, 'w') as file:
     file.write(exchange_log)


### PR DESCRIPTION
I made a really good generation with maestro but it failed at the end because the filename (objective) was too long. I wasn't able to save the final output in markdown. This fixes by prefixing the objective in filename with an md5 hash in case the string length is too long.