### PR TITLE
Retrieve the API key from the environment settings

### DIFF
--- a/maestro.py
+++ b/maestro.py
@@ -6,7 +6,7 @@ from rich.panel import Panel
 from datetime import datetime
 
 # Set up the Anthropic API client
-client = Anthropic(api_key="")
+client = Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY") or "")
 
 # Initialize the Rich Console
 console = Console()


### PR DESCRIPTION
The client does not read the `ANTHROPIC_API_KEY` from env as the docs suggest. I was getting the following error even though the `ANTHROPIC_API_KEY` was in my env: 

```TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"```

So, added getenv to explicitly take the api key from the environment 