### PR TITLE
Changes to requirements.txt and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To run this script, you need to have the following:
 2. Install the required Python packages by running the following command:
 
 ```bash
-pip install -r requirements.txt
+pip install -r flask_app/requirements.txt
 ```
 
 3. Replace the placeholder API key in the script with your actual Anthropic API key:

--- a/flask_app/requirements.txt
+++ b/flask_app/requirements.txt
@@ -5,3 +5,4 @@ ollama
 groq
 openai
 Flask
+google-generativeai


### PR DESCRIPTION
1. Added `google-generativeai` to requirements.txt to prevent the below error when running **maestro-anyapi.py**
```shell
 import google.generativeai as genai  # type: ignore
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'google.generativeai'
``` 

2. Updated README.md to reflect the new filepath for 
**requirements.txt**